### PR TITLE
email column added to reply to the resourcequota request

### DIFF
--- a/src/synchronizer.rs
+++ b/src/synchronizer.rs
@@ -68,6 +68,9 @@ struct Row {
     // description (unused)
     // description: String,
 
+    // email (unused)
+    // email: String,
+
     // real name
     name: String,
     // username in id.snucse.org
@@ -123,6 +126,9 @@ fn try_infer_header(header: impl AsRef<str>) -> Result<String, Error> {
     }
     if header.contains("승인") {
         return Ok("authorized".to_string());
+    }
+    if header.contains("이메일") {
+        return Ok("email".to_string());
     }
 
     return Err(Error::CsvHeaderError(format!(


### PR DESCRIPTION
승인 여부를 알려주기 위해서 이메일 답장이 필요합니다. 따라서 이메일 컬럼을 넣어야하기에 코드에서 header 파싱 부분에 이메일을 추가했습니다. 

매우 간단한 코드라 그냥 머지해놓겠습니다. 태그랑 릴리즈는 안해놓을게요.